### PR TITLE
Upgrade gradle plugin and other libraries to the latest versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,17 +6,16 @@ plugins {
     id("com.diffplug.spotless") version "6.22.0"
 }
 
-val testIntegrationVersion = "1.6.1"
-val fragmentVersion = "1.8.1"
+val fragmentVersion = "1.8.6"
 
 android {
     namespace = "com.josdem.fruitypedia"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.josdem.fruitypedia"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 8
         versionName = "1.2.0"
 
@@ -41,6 +40,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 }
 
@@ -61,13 +61,13 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
     implementation("androidx.navigation:navigation-fragment-ktx:2.8.9")
     implementation("androidx.navigation:navigation-ui-ktx:2.8.9")
-    implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.11.0")
     implementation(platform("com.google.firebase:firebase-bom:33.10.0"))
     implementation("com.google.firebase:firebase-analytics")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("io.mockk:mockk:1.13.8")
+    testImplementation("io.mockk:mockk:1.13.17")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
 
@@ -80,6 +80,6 @@ dependencies {
     debugImplementation("androidx.tracing:tracing:1.2.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     //noinspection GradleDependency
-    androidTestImplementation("androidx.test:runner:$testIntegrationVersion")
-    androidTestImplementation("androidx.test:rules:$testIntegrationVersion")
+    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test:rules:1.6.1")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,12 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("com.google.gms.google-services")
-    id("com.diffplug.spotless") version "6.22.0"
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.diffplug.spotless)
 }
-
-val fragmentVersion = "1.8.6"
 
 android {
     namespace = "com.josdem.fruitypedia"
@@ -55,31 +53,31 @@ spotless {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.15.0")
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("com.google.android.material:material:1.12.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.8.9")
-    implementation("androidx.navigation:navigation-ui-ktx:2.8.9")
-    implementation("com.squareup.retrofit2:retrofit:2.11.0")
-    implementation("com.squareup.retrofit2:converter-gson:2.11.0")
-    implementation(platform("com.google.firebase:firebase-bom:33.10.0"))
-    implementation("com.google.firebase:firebase-analytics")
+    implementation(libs.androidx.ktx)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.material)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.navigation.fragment.ktx)
+    implementation(libs.androidx.navigation.ui.ktx)
+    implementation(libs.retrofit)
+    implementation(libs.converter.gson)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("io.mockk:mockk:1.13.17")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+    androidTestImplementation(libs.androidx.junit)
 
     // TODO: Remove debugImplementation since it is a temporary fix for this JUnit issue:
     // https://github.com/android/android-test/issues/1755
     //noinspection GradleDependency
-    debugImplementation("androidx.fragment:fragment-testing-manifest:$fragmentVersion")
+    debugImplementation(libs.androidx.fragment.testing.manifest)
     //noinspection GradleDependency
-    androidTestImplementation("androidx.fragment:fragment-testing:$fragmentVersion")
-    debugImplementation("androidx.tracing:tracing:1.2.0")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation(libs.androidx.fragment.testing)
+    debugImplementation(libs.androidx.tracing)
+    androidTestImplementation(libs.androidx.espresso.core)
     //noinspection GradleDependency
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test:rules:1.6.1")
+    androidTestImplementation(libs.androidx.runner)
+    androidTestImplementation(libs.androidx.rules)
 }

--- a/app/src/main/java/com/josdem/fruitypedia/MainActivity.kt
+++ b/app/src/main/java/com/josdem/fruitypedia/MainActivity.kt
@@ -19,6 +19,7 @@ package com.josdem.fruitypedia
 
 import android.os.Bundle
 import android.util.Log
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
@@ -43,6 +44,7 @@ class MainActivity : AppCompatActivity() {
     private var clickCounter: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         val dexOutputDir: File = codeCacheDir

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,6 +9,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
         android:theme="@style/Theme.Fruitypedia.AppBarOverlay">
 
         <androidx.appcompat.widget.Toolbar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.9.0" apply false
-    id("com.android.library") version "8.9.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.20-RC3" apply false
-    id("com.google.gms.google-services") version "4.4.2" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.google.services) apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.5.2" apply false
-    id("com.android.library") version "8.5.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.10" apply false
+    id("com.android.application") version "8.9.0" apply false
+    id("com.android.library") version "8.9.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.20-RC3" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,50 @@
+[versions]
+androidGradlePlugin = "8.9.0"
+appcompat = "1.7.0"
+constraintlayout = "2.2.1"
+diffplugSpotlessPlugin = "6.22.0"
+espressoCore = "3.6.1"
+firebaseBom = "33.10.0"
+fragmentVersion = "1.8.6"
+googleServicesPlugin = "4.4.2"
+junit = "4.13.2"
+junitVersion = "1.2.1"
+kotlinGradlePlugin = "2.1.20-RC3"
+kotlinxCoroutinesTest = "1.8.1"
+ktx = "1.15.0"
+material = "1.12.0"
+mockk = "1.13.17"
+navigationFragmentKtx = "2.8.9"
+retrofit = "2.11.0"
+rules = "1.6.1"
+runner = "1.6.2"
+tracing = "1.2.0"
+
+[libraries]
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
+androidx-fragment-testing = { module = "androidx.fragment:fragment-testing", version.ref = "fragmentVersion" }
+androidx-fragment-testing-manifest = { module = "androidx.fragment:fragment-testing-manifest", version.ref = "fragmentVersion" }
+androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
+androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
+androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
+androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationFragmentKtx" }
+androidx-rules = { module = "androidx.test:rules", version.ref = "rules" }
+androidx-runner = { module = "androidx.test:runner", version.ref = "runner" }
+androidx-tracing = { module = "androidx.tracing:tracing", version.ref = "tracing" }
+converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+diffplug-spotless = { id = "com.diffplug.spotless", version.ref = "diffplugSpotlessPlugin" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesPlugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinGradlePlugin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jun 23 11:53:20 EDT 2024
+#Sun Mar 16 16:51:16 BDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Closes: #90 
Closes: #91
Problem: Gradle plugin and other libraries are not in their latest versions
Solution: Upgrade gradle plugins and other libraries to the latest versions

- upgrade gradle plugin to the latest version
- upgrade other libraries to their latest versions
- upgrade targetSdk and compileSdk to 35
- upgrade gradle to 8.11.1
- remove android.defaults.buildfeatures.buildconfig as it is deprecated
- add support for edge-to-edge because of SDK 35
- migrate to version catalog