### PR TITLE
Enable gradle configuration cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 app/release/
 local.properties.DS_Store
 **/.DS_Store
+local.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,5 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false
+# Enable gradle configuration cache
+org.gradle.configuration-cache=true


### PR DESCRIPTION
Closes: #94
Problem: No gradle configuration cache is currently used in this project
Solution: Enable gradle configuration cache in the gradle.properties file